### PR TITLE
openshift-apps: add coreos-ostree-importer as POC

### DIFF
--- a/playbooks/openshift-apps/coreos-ostree-importer.yml
+++ b/playbooks/openshift-apps/coreos-ostree-importer.yml
@@ -1,0 +1,41 @@
+- name: make the app be real
+  hosts: os_masters_stg[0]
+  user: root
+  gather_facts: False
+
+  vars_files:
+    - /srv/web/infra/ansible/vars/global.yml
+    - "/srv/private/ansible/vars.yml"
+    - /srv/web/infra/ansible/vars/{{ ansible_distribution }}.yml
+
+  roles:
+  - role: openshift/project
+    app: coreos-ostree-importer
+    description: Imports OSTree commits into Fedora from the Fedora CoreOS pipeline
+    appowners:
+    - dustymabe
+    - jlebon
+    - kevin
+
+  - role: openshift/object
+    template: deploymentconfig.yml
+    objectname: deploymentconfig.yml
+
+  - role: openshift/object
+    app: coreos-ostree-importer
+    template: pvc.yml
+    objectname: pvc.yml
+
+  - role: openshift/rollout
+    app: coreos-ostree-importer
+    dcname: coreos-ostree-importer
+
+###############################################
+# actions to delete the project from OpenShift
+###############################################
+# to run: sudo rbac-playbook -l os_masters_stg[0] -t delete openshift-apps/coreos-ostree-importer.yml
+  - role: openshift/object-delete
+    app: coreos-ostree-importer
+    objecttype: project
+    objectname: coreos-ostree-importer
+    tags: [ never, delete ]

--- a/roles/openshift-apps/coreos-ostree-importer/templates/deploymentconfig.yml
+++ b/roles/openshift-apps/coreos-ostree-importer/templates/deploymentconfig.yml
@@ -1,0 +1,38 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: coreos-ostree-importer
+  name: coreos-ostree-importer
+spec:
+  replicas: 1
+  selector:
+    app: coreos-ostree-importer
+  strategy:
+    resources: {}
+  template:
+    metadata:
+      labels:
+        app: coreos-ostree-importer
+      name: coreos-ostree-importer
+    spec:
+      containers:
+        name: coreos-ostree-importer
+        image: registry.fedoraproject.org/fedora:30
+        # sleep infinity is useful for debugging environment issues
+        # comment out when not debugging
+        args: ['infinity']
+        command: ['/usr/bin/sleep']
+        volumeMounts:
+        - name: fedora-ostree-content-volume
+          mountPath: /mnt/koji
+        imagePullPolicy: IfNotPresent
+        resources: {}
+      volumes:
+      - name: fedora-ostree-content-volume
+        persistentVolumeClaim:
+          claimName: fedora-ostree-content-volume
+      restartPolicy: Always
+  test: false
+  triggers:
+  - type: ConfigChange

--- a/roles/openshift-apps/coreos-ostree-importer/templates/pvc.yml
+++ b/roles/openshift-apps/coreos-ostree-importer/templates/pvc.yml
@@ -1,0 +1,12 @@
+# PVC to mount the fedora-ostree-content-volume NFS share
+# that has been mapped in to OpenShift by Fedora Infra for
+# us from the NetApp. This corresponds to the fedora-ostree-content
+# NetApp volume which is mounted in other places as well.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fedora-ostree-content-volume
+spec:
+  accessModes:
+    - ReadWriteMany
+  volumeName: "fedora-ostree-content-volume"


### PR DESCRIPTION
This project will eventually be used to import ostree content
from the Fedora CoreOS pipeline, but for now we're just using it
to test that we can mount our created NetApp share inside of OpenShift
using NFS mounts.