### PR TITLE
openshift-apps: add fedora-ostree-pruner application as POC

### DIFF
--- a/playbooks/openshift-apps/fedora-ostree-pruner.yml
+++ b/playbooks/openshift-apps/fedora-ostree-pruner.yml
@@ -1,0 +1,42 @@
+- name: make the app be real
+  hosts: os_masters_stg[0]
+  user: root
+  gather_facts: False
+
+  vars_files:
+    - /srv/web/infra/ansible/vars/global.yml
+    - "/srv/private/ansible/vars.yml"
+    - /srv/web/infra/ansible/vars/{{ ansible_distribution }}.yml
+
+  roles:
+  - role: openshift/project
+    app: fedora-ostree-pruner
+    description: Prunes OSTree repositories based on policy
+    appowners:
+    - dustymabe
+    - jlebon
+    - kevin
+
+  - role: openshift/object
+    app: fedora-ostree-pruner
+    template: deploymentconfig.yml
+    objectname: deploymentconfig.yml
+
+  - role: openshift/object
+    app: fedora-ostree-pruner
+    template: pvc.yml
+    objectname: pvc.yml
+
+  - role: openshift/rollout
+    app: fedora-ostree-pruner
+    dcname: fedora-ostree-pruner
+
+###############################################
+# actions to delete the project from OpenShift
+###############################################
+# to run: sudo rbac-playbook -l os_masters_stg[0] -t delete openshift-apps/fedora-ostree-pruner.yml
+  - role: openshift/object-delete
+    app: fedora-ostree-pruner
+    objecttype: project
+    objectname: fedora-ostree-pruner
+    tags: [ never, delete ]

--- a/roles/openshift-apps/fedora-ostree-pruner/templates/deploymentconfig.yml
+++ b/roles/openshift-apps/fedora-ostree-pruner/templates/deploymentconfig.yml
@@ -1,0 +1,38 @@
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  labels:
+    app: fedora-ostree-pruner
+  name: fedora-ostree-pruner
+spec:
+  replicas: 1
+  selector:
+    app: fedora-ostree-pruner
+  strategy:
+    resources: {}
+  template:
+    metadata:
+      labels:
+        app: fedora-ostree-pruner
+      name: fedora-ostree-pruner
+    spec:
+      containers:
+      - name: fedora-ostree-pruner
+        image: registry.fedoraproject.org/fedora:30
+        # sleep infinity is useful for debugging environment issues
+        # comment out when not debugging
+        args: ['infinity']
+        command: ['/usr/bin/sleep']
+        volumeMounts:
+        - name: fedora-ostree-content-volume
+          mountPath: /mnt/koji
+        imagePullPolicy: IfNotPresent
+        resources: {}
+      volumes:
+      - name: fedora-ostree-content-volume
+        persistentVolumeClaim:
+          claimName: fedora-ostree-content-volume
+      restartPolicy: Always
+  test: false
+  triggers:
+  - type: ConfigChange

--- a/roles/openshift-apps/fedora-ostree-pruner/templates/pvc.yml
+++ b/roles/openshift-apps/fedora-ostree-pruner/templates/pvc.yml
@@ -1,0 +1,17 @@
+# PVC to mount the fedora-ostree-content-volume NFS share
+# that has been mapped in to OpenShift by Fedora Infra for
+# us from the NetApp. This corresponds to the fedora-ostree-content
+# NetApp volume which is mounted in other places as well.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: fedora-ostree-content-volume
+spec:
+  volumeName: "fedora-ostree-content-volume"
+  # This values are mostly ignored since we're using a named
+  # volume, but are required.
+  accessModes:
+    - ReadWriteMany
+  resources:
+    requests:
+      storage: 1Gi


### PR DESCRIPTION
This project will eventually be used to prune ostree repo content
based on a stated policy, but for now we're just using it to test
that we can mount our created NetApp share inside of OpenShift
using NFS mounts.